### PR TITLE
Dawni: switch to eval and add commands

### DIFF
--- a/app/dawni.hs
+++ b/app/dawni.hs
@@ -5,9 +5,15 @@
 
 module Main where
 
+import Control.Exception
 import Control.Monad
+import Control.Monad.IO.Class
+import Data.List
+import qualified Data.Map as Map
+import Data.Maybe
 import Language.Dawn.Phase1.Core
 import Language.Dawn.Phase1.Display
+import Language.Dawn.Phase1.Eval
 import Language.Dawn.Phase1.Parse
 import Language.Dawn.Phase1.PartialEval
 import Language.Dawn.Phase1.Utils
@@ -16,22 +22,45 @@ import System.IO
 
 main = do
   putStrLn "Dawn Phase 1 Interpreter"
-  runInputT defaultSettings readEvalPrintLoop
+  runInputT defaultSettings (readEvalPrintLoop (MultiStack Map.empty))
 
-readEvalPrintLoop = readEvalPrint >> readEvalPrintLoop
+readEvalPrintLoop :: MultiStack -> InputT IO MultiStack
+readEvalPrintLoop ms = do
+  ms' <- readEvalPrint ms
+  readEvalPrintLoop ms'
 
-readEvalPrint = do
+readEvalPrint :: MultiStack -> InputT IO MultiStack
+readEvalPrint ms = do
   maybeLine <- getInputLine "> "
   case maybeLine of
-    Nothing -> return ()
-    Just line -> case parseExpr line of
-      Left err -> outputStrLn (show err)
-      Right e -> do
-        printExprType e
-        when (e /= partialEval' e) $ printExprType (partialEval' e)
+    Nothing -> return ms
+    Just line | ":print " `isPrefixOf` line -> do
+      case parseExpr (fromJust $ stripPrefix ":print " line) of
+        Left err -> outputStrLn (show err)
+        Right e ->
+          case inferNormType' e of
+            Left err -> outputStrLn $ display e ++ " is not typeable. " ++ display err
+            Right t -> outputStrLn $ display e ++ " :: " ++ display t
+      return ms
+    Just line ->
+      case parseExpr line of
+        Left err -> do
+          outputStrLn (show err)
+          return ms
+        Right e ->
+          case inferNormType' e of
+            Left err -> do
+              outputStrLn $ display e ++ " is not typeable. " ++ display err
+              return ms
+            Right t -> do
+              result <- try' (evaluate (eval ["$"] e ms))
+              case (result :: Either SomeException MultiStack) of
+                Left err -> do
+                  outputStrLn $ show err
+                  return ms
+                Right ms' -> do
+                  outputStrLn $ display ms'
+                  return ms'
 
-printExprType e = do
-  outputStr (display e)
-  case inferNormType' e of
-    Left e -> outputStrLn $ " is not typeable. " ++ display e
-    Right t -> outputStrLn $ " :: " ++ display t
+try' :: Exception e => IO a -> InputT IO (Either e a)
+try' = liftIO . Control.Exception.try

--- a/src/Language/Dawn/Phase1/Display.hs
+++ b/src/Language/Dawn/Phase1/Display.hs
@@ -9,6 +9,7 @@ import Data.List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Language.Dawn.Phase1.Core
+import Language.Dawn.Phase1.Eval
 
 class Display t where
   display :: t -> String
@@ -63,8 +64,8 @@ instance Display Type where
   display (TCons tc) = display tc
 
 displayMultiIO mio
-  | Map.keys mio == [""] =
-    let [("", (i, o))] = Map.toList mio
+  | Map.keys mio == ["$"] =
+    let [("$", (i, o))] = Map.toList mio
      in display i ++ " -> " ++ display o
   | otherwise = intercalate " . " (map iter (Map.toAscList mio))
   where
@@ -93,3 +94,11 @@ instance Display a => Display [a] where
 
 instance (Display a, Display b) => Display (a, b) where
   display (a, b) = "(" ++ display a ++ ", " ++ display b ++ ")"
+
+instance Display MultiStack where
+  display (MultiStack m) = intercalate "\n" (map iter (Map.toAscList m))
+    where
+      iter (sid, vs) = sid ++ ": " ++ unwords (map display (reverse vs))
+
+instance Display Val where
+  display v = display (fromVal v)

--- a/src/Language/Dawn/Phase1/Eval.hs
+++ b/src/Language/Dawn/Phase1/Eval.hs
@@ -6,8 +6,10 @@
 module Language.Dawn.Phase1.Eval
   ( eval,
     eval',
+    fromVal,
     fromValSeq,
     MultiStack (..),
+    toVal,
     toValSeq,
     Val (..),
   )

--- a/src/Language/Dawn/Phase1/Parse.hs
+++ b/src/Language/Dawn/Phase1/Parse.hs
@@ -3,7 +3,13 @@
 -- Licensed under either the Apache License, Version 2.0 (see LICENSE-APACHE),
 -- or the ZLib license (see LICENSE-ZLIB), at your option.
 
-module Language.Dawn.Phase1.Parse (parseExpr, parseVal) where
+module Language.Dawn.Phase1.Parse
+  ( expr,
+    keyword,
+    parseExpr,
+    parseVal,
+  )
+where
 
 import Control.Monad (void)
 import Language.Dawn.Phase1.Core


### PR DESCRIPTION
- switch to calling `eval` on the entered expression, by default
- add the `:exit`, `:clear`, `:print` and `:partialEval` commands