### PR TITLE
fix unifyCaseTypes

### DIFF
--- a/src/Language/Dawn/Phase1/Core.hs
+++ b/src/Language/Dawn/Phase1/Core.hs
@@ -504,12 +504,13 @@ caseType ctx (p, e) = do
 unifyCaseTypes :: [Type] -> Result Type
 unifyCaseTypes [] = error "empty match"
 unifyCaseTypes [t@TFn {}] = return t
-unifyCaseTypes (t1@TFn {} : t2@TFn {} : ts) = do
-  let (t1', t2', reserved1) = addMissingStacks (t1, t2, Set.empty)
-  let ((t1'', t2''), reserved2) = instantiate (t1', t2') reserved1
-  (s, reserved3) <- mgu t1'' t2'' reserved2
-  let TFn _ mio1 = t1''
-  let (mio3, _) = subs s mio1 reserved3
+unifyCaseTypes (f1@TFn {} : f2@TFn {} : ts) = do
+  let (f1', reserved1) = instantiate f1 Set.empty
+  let (f2', reserved2) = instantiate f2 reserved1
+  let (f1'', f2'', reserved3) = addMissingStacks (f1', f2', reserved2)
+  (s, reserved4) <- mgu f1'' f2'' reserved3
+  let TFn _ mio1 = f1''
+  let (mio3, _) = subs s mio1 reserved4
   let t3 = requantify (TFn Set.empty mio3)
   unifyCaseTypes (t3 : ts)
 

--- a/test/Language/Dawn/Phase1/CoreSpec.hs
+++ b/test/Language/Dawn/Phase1/CoreSpec.hs
@@ -278,3 +278,8 @@ spec = do
       let (Right e) = parseExpr "{match {case 0 0 => 1} {case => drop drop 0}}"
       inferNormType ["$"] e
         `shouldBe` Right (forall' [v0] (v0 * tU32 * tU32 --> v0 * tU32))
+
+    it "infers `{match {case 0 => [clone] apply} {case => drop [clone] apply}}`" $ do
+      let (Right e) = parseExpr "{match {case 0 => [clone] apply} {case => drop [clone] apply}}"
+      inferNormType ["$"] e
+        `shouldBe` Right (forall' [v0, v1] (v0 * v1 * tU32 --> v0 * v1 * v1))


### PR DESCRIPTION
We must instantiate the two function types separately, rather than together.