### PR TITLE
Remove FnDiverges in favor of FnTypeDiverges

### DIFF
--- a/app/dawni.hs
+++ b/app/dawni.hs
@@ -67,8 +67,8 @@ readEvalPrint (env, ms) = do
           let s = intercalate ", " (Set.toList sids)
           outputStrLn ("Error: exposed temporary stacks: " ++ s)
           return (env, ms)
-        Left (FnDiverges _) -> do
-          outputStrLn ("Error: function diverges: " ++ fid)
+        Left (FnTypeDiverges _) -> do
+          outputStrLn ("Error: function type diverges: " ++ fid)
           return (env, ms)
         Right env' -> do
           let (Just (_, t)) = Map.lookup fid env'

--- a/test/Language/Dawn/Phase1/CoreSpec.hs
+++ b/test/Language/Dawn/Phase1/CoreSpec.hs
@@ -285,33 +285,36 @@ spec = do
         `shouldBe` Right (forall' [v0, v1] (v0 * v1 * tU32 --> v0 * v1 * v1))
 
   describe "fnDefType examples" $ do
-    it "fails with FnDiverges if trivially diverges" $ do
+    it "infers {fn test = test} :: (∀ v0 v1 . v0 -> v1)" $ do
       let (Right f) = parseFnDef "{fn test = test}"
       fnDefType Map.empty f
-        `shouldBe` Left (FnDiverges "test")
+        `shouldBe` Right (forall' [v0, v1] (v0 --> v1))
 
+    it "infers {fn test = 0 test} :: (∀ v0 v1 . v0 -> v1)" $ do
       let (Right f) = parseFnDef "{fn test = 0 test}"
       fnDefType Map.empty f
-        `shouldBe` Left (FnDiverges "test")
+        `shouldBe` Right (forall' [v0, v1] (v0 --> v1))
 
   describe "recFnDefType examples" $ do
-    it "fails with FnDiverges if trivially diverges" $ do
+    it "infers {fn test = test} :: (∀ v0 v1 . v0 -> v1)" $ do
       let (Right f) = parseFnDef "{fn test = test}"
       recFnDefType Map.empty f
-        `shouldBe` Left (FnDiverges "test")
+        `shouldBe` Right (forall' [v0, v1] (v0 --> v1))
 
+    it "infers {fn test = 0 test} :: (∀ v0 v1 . v0 -> v1)" $ do
       let (Right f) = parseFnDef "{fn test = 0 test}"
       recFnDefType Map.empty f
-        `shouldBe` Left (FnDiverges "test")
+        `shouldBe` Right (forall' [v0, v1] (v0 --> v1))
 
-    it "fails with FnDiverges if type unstable" $ do
+    it "fails {fn test = test 0} with FnTypeDiverges" $ do
       let (Right f) = parseFnDef "{fn test = test 0}"
       recFnDefType Map.empty f
-        `shouldBe` Left (FnDiverges "test")
+        `shouldBe` Left (FnTypeDiverges "test")
 
+    it "fails {fn test = drop test 0} with FnTypeDiverges" $ do
       let (Right f) = parseFnDef "{fn test = drop test 0}"
       recFnDefType Map.empty f
-        `shouldBe` Left (FnDiverges "test")
+        `shouldBe` Left (FnTypeDiverges "test")
 
   describe "defineFn examples" $ do
     it "defines drop2" $ do


### PR DESCRIPTION
We'll want to be able to define and run functions that trivially diverge, such as a TCP server. Eventually we'll add a bottom type and require annotating the output as such. For now, we infer `(∀ v0 v1 . v0 -> v1)`.

However, we still want to ban functions that do not have a stable inferred type. For those, we return `FnTypeDiverges`.