### PR TITLE
Conditionality-aware dependency sorting

### DIFF
--- a/src/Language/Dawn/Phase1/Core.hs
+++ b/src/Language/Dawn/Phase1/Core.hs
@@ -871,18 +871,12 @@ fnDepsSort defs =
               (False, False, False, True) -> GT
               (False, False, True, False) -> LT
               (False, False, True, True) -> EQ
-              (False, True, False, False) -> error "impossible"
               (False, True, False, True) -> GT
-              (False, True, True, False) -> error "impossible"
               (False, True, True, True) -> GT
-              (True, False, False, False) -> error "impossible"
-              (True, False, False, True) -> error "impossible"
               (True, False, True, False) -> LT
               (True, False, True, True) -> LT
-              (True, True, False, False) -> error "impossible"
-              (True, True, False, True) -> error "impossible"
-              (True, True, True, False) -> error "impossible"
               (True, True, True, True) -> EQ
+              _ -> error "unreachable"
    in sortBy fnDepsOrdering (dependencySortFns defs)
   where
     fnDefToEdgeList exprToDeps def@(FnDef fid e) = (def, fid, Set.toList (exprToDeps e))

--- a/test/Language/Dawn/Phase1/CoreSpec.hs
+++ b/test/Language/Dawn/Phase1/CoreSpec.hs
@@ -364,10 +364,48 @@ spec = do
       let t = forall' [v0, v1] (v0 * v1 * v1 --> v0 * v1)
       checkType' e t `shouldBe` Left (MatchError (DoesNotMatch tBool v1))
   
-  describe "fnDefs" $ do
+  describe "directFnDeps" $ do
     it "separates conditional and unconditional dependencies" $ do
       let (Right e) = parseExpr "f1 {match {case True => f2 f3} {case => f2 f4}}"
-      fnDeps e `shouldBe` (Set.fromList ["f3", "f4"], Set.fromList ["f1", "f2"])
+      directFnDeps e `shouldBe` (Set.fromList ["f3", "f4"], Set.fromList ["f1", "f2"])
+  
+  describe "fnDepsSort" $ do
+    -- f ~> g := f directly depends on g
+    -- f ~!> g := f directly and unconditionally depends on g
+    -- f ~?> g := f directly and conditionally depends on g
+    -- f ~~> g := f transitively depends on g
+    
+    it "f < g if f ~!> g and not g ~~> f" $ do
+      let (Right f) = parseFnDef "{fn f => g}"
+      let (Right g) = parseFnDef "{fn g => }"
+      directFnDeps (fnDefExpr f) `shouldBe` (Set.fromList [], Set.fromList ["g"])
+      directFnDeps (fnDefExpr g) `shouldBe` (Set.fromList [], Set.fromList [])
+      fnDepsSort [f, g] `shouldBe` [f, g]
+      fnDepsSort [g, f] `shouldBe` [f, g]
+
+    it "f < g if f ~?> g and not g ~~> f" $ do
+      let (Right f) = parseFnDef "{fn f => {match {case False => g} {case True => }}}"
+      let (Right g) = parseFnDef "{fn g => }"
+      directFnDeps (fnDefExpr f) `shouldBe` (Set.fromList ["g"], Set.fromList [])
+      directFnDeps (fnDefExpr g) `shouldBe` (Set.fromList [], Set.fromList [])
+      fnDepsSort [f, g] `shouldBe` [f, g]
+      fnDepsSort [g, f] `shouldBe` [f, g]
+
+    -- it "f < g if f ~!> g and not g ~~!> f" $ do
+    -- it "f < g if f ~~!> g and not g ~~> f" $ do
+    -- it "f < g if f ~~?> g and not g ~~> f" $ do
+    -- it "f < g if f ~~!> g and not g ~~!> f" $ do
+
+    -- it "f < g if f ~~> g and not g ~~> f" $ do
+    --   let (Right f) = parseFnDef "{fn f => {match {case False => h} {case True => }}}"
+    --   let (Right h) = parseFnDef "{fn h => g}"
+    --   let (Right g) = parseFnDef "{fn g => }"
+    --   fnDepsSort [f, h, g] `shouldBe` [f, h, g]
+    --   fnDepsSort [f, g, h] `shouldBe` [f, h, g]
+    --   fnDepsSort [h, f, g] `shouldBe` [f, h, g]
+    --   fnDepsSort [h, g, f] `shouldBe` [f, h, g]
+    --   fnDepsSort [g, f, h] `shouldBe` [f, h, g]
+    --   fnDepsSort [g, h, f] `shouldBe` [f, h, g]
 
   describe "dependencySortFns examples" $ do
     it "sorts drop2 drop3" $ do
@@ -539,11 +577,7 @@ spec = do
       let env = Map.empty
       defineFns Map.empty [is_even, is_odd] `shouldBe` (errs, env)
 
-    -- NOTE: the following two tests restrict the implementation of dependencySortFns
-    -- so that this test fails and the next succeeds.
-    -- TODO: once we add function type declarations, decide how to alter the
-    -- specification and implementation so that both of these tests fail.
-    it "fails on mutual recursion in all but some match cases in one function (1)" $ do
+    it "succeeds on mutual recursion in all but some match cases in one function (1)" $ do
       let is_even_es =
             "{match"
               ++ "  {case 0 => True}"
@@ -559,12 +593,13 @@ spec = do
       let (Right is_odd_e) = parseExpr is_odd_es
       let is_odd_t = forall' [v0] (v0 * tU32 --> v0 * tBool)
 
-      let errs =
-            [ FnTypeError "is_odd" (UndefinedFn "is_even"),
-              FnTypeError "is_even" (UndefinedFn "is_odd")
-            ]
-      let env = Map.empty
-      defineFns Map.empty [is_even, is_odd] `shouldBe` (errs, env)
+      let errs = []
+      let env =
+            Map.fromList
+              [ ("is_odd", (is_odd_e, is_odd_t)),
+                ("is_even", (is_even_e, is_even_t))
+              ]
+      defineFns Map.empty [is_odd, is_even] `shouldBe` (errs, env)
 
     it "succeeds on mutual recursion in all but some match cases in one function (2)" $ do
       let is_odd_es =

--- a/test/Language/Dawn/Phase1/CoreSpec.hs
+++ b/test/Language/Dawn/Phase1/CoreSpec.hs
@@ -363,6 +363,11 @@ spec = do
       let (Right e) = parseExpr "and"
       let t = forall' [v0, v1] (v0 * v1 * v1 --> v0 * v1)
       checkType' e t `shouldBe` Left (MatchError (DoesNotMatch tBool v1))
+  
+  describe "fnDefs" $ do
+    it "separates conditional and unconditional dependencies" $ do
+      let (Right e) = parseExpr "f1 {match {case True => f2 f3} {case => f2 f4}}"
+      fnDeps e `shouldBe` (Set.fromList ["f3", "f4"], Set.fromList ["f1", "f2"])
 
   describe "dependencySortFns examples" $ do
     it "sorts drop2 drop3" $ do

--- a/test/Language/Dawn/Phase1/CoreSpec.hs
+++ b/test/Language/Dawn/Phase1/CoreSpec.hs
@@ -365,6 +365,16 @@ spec = do
       let t = forall' [v0, v1] (v0 * v1 * v1 --> v0 * v1)
       checkType' e t `shouldBe` Left (MatchError (DoesNotMatch tBool v1))
 
+  describe "fnDeps" $ do
+    it "returns all dependencies" $ do
+      let (Right e) = parseExpr "f1 {match {case True => f2 f3} {case => f2 f4}}"
+      fnDeps e `shouldBe` (Set.fromList ["f1", "f2", "f3", "f4"])
+
+  describe "uncondFnDeps" $ do
+    it "returns unconditional dependencies" $ do
+      let (Right e) = parseExpr "f1 {match {case True => f2 f3} {case => f2 f4}}"
+      uncondFnDeps e `shouldBe` (Set.fromList ["f1", "f2"])
+
   describe "directFnDeps" $ do
     it "separates conditional and unconditional dependencies" $ do
       let (Right e) = parseExpr "f1 {match {case True => f2 f3} {case => f2 f4}}"

--- a/test/Language/Dawn/Phase1/CoreSpec.hs
+++ b/test/Language/Dawn/Phase1/CoreSpec.hs
@@ -430,13 +430,6 @@ spec = do
       let fnDefs = [f, h, g]
       mapM_ (\defs -> fnDepsSort defs `shouldBe` fnDefs) (permutations fnDefs)
 
-  describe "dependencySortFns examples" $ do
-    it "sorts drop2 drop3" $ do
-      let (Right drop2) = parseFnDef "{fn drop2 => drop drop}"
-      let (Right drop3) = parseFnDef "{fn drop3 => drop2 drop}"
-      dependencySortFns [drop2, drop3]
-        `shouldBe` [drop3, drop2]
-
   describe "defineFns examples" $ do
     it "defines drop2 and drop3" $ do
       let (Right drop2) = parseFnDef "{fn drop2 => drop drop}"


### PR DESCRIPTION
Sort FnDef's such that f precedes g if f depends on g
(directly or transitively) and g does not depend on f,
or if f unconditionally depends on g and g does not
unconditionally depend on f.

Note that f conditionally depends on g if there is at
least one match case that does not depend on g.
Otherwise, f unconditionally depends on g.

This should enable type inference on any mutually recursive
total functions, since in order to be total there must be
at least one match case that does not recurse.