### PR TITLE
Improve type inference of recursive functions

### DIFF
--- a/src/Language/Dawn/Phase1/Core.hs
+++ b/src/Language/Dawn/Phase1/Core.hs
@@ -888,8 +888,9 @@ defineFns env defs =
       newFnIds = Set.fromList (map fnDefFnId defs')
       sortedDefs = fnDepsSort defs'
       (errs2, env2, sortedDefs') = foldr (inferTypes newFnIds) ([], env, []) sortedDefs
-      (errs3, env3) = foldr (checkTypes newFnIds) ([], env2) sortedDefs'
-   in (errs1 ++ errs2 ++ errs3, env3)
+      (errs3, env3, sortedDefs'') = foldr (inferTypes newFnIds) ([], env2, []) sortedDefs'
+      (errs4, env4) = foldr (checkTypes newFnIds) ([], env3) sortedDefs''
+   in (errs1 ++ errs2 ++ errs3 ++ errs4, env4)
   where
     removeAlreadyDefined :: FnIds -> [FnDef] -> ([FnDefError], [FnDef])
     removeAlreadyDefined fids [] = ([], [])

--- a/test/Language/Dawn/Phase1/ParseSpec.hs
+++ b/test/Language/Dawn/Phase1/ParseSpec.hs
@@ -251,3 +251,23 @@ spec = do
       let (Right e) = parseExpr fibExprSrc
       parseFnDef fibSrc
         `shouldBe` Right (FnDef "fib" e)
+
+    it "parses tail recursive fib" $ do
+      let fibExprSrc = "0 1 _fib"
+      let fibSrc = "{fn fib => " ++ fibExprSrc ++ "}"
+      let (Right e) = parseExpr fibExprSrc
+      parseFnDef fibSrc
+        `shouldBe` Right (FnDef "fib" e)
+
+      let _fibExprSrc =
+            unlines
+              [ "  {spread $a $b}",
+                "  {match",
+                "    {case 0 => {$b drop} $a->}",
+                "    {case => decr $b-> clone $a-> add _fib}",
+                "  }"
+              ]
+      let _fibSrc = "{fn _fib => " ++ _fibExprSrc ++ "}"
+      let (Right e) = parseExpr _fibExprSrc
+      parseFnDef _fibSrc
+        `shouldBe` Right (FnDef "_fib" e)


### PR DESCRIPTION
Improve type inference of recursive functions by adding an extra round of `inferTypes`. This enables type inference of a broader class of recursive functions, such as a tail-recursive function for calculating the Nth Fibonacci number.