### PR TITLE
dawni: add `:trace` command

### DIFF
--- a/src/Language/Dawn/Phase1/Core.hs
+++ b/src/Language/Dawn/Phase1/Core.hs
@@ -888,8 +888,9 @@ defineFns env defs =
       newFnIds = Set.fromList (map fnDefFnId defs')
       sortedDefs = fnDepsSort defs'
       (errs2, env2, sortedDefs') = foldr (inferTypes newFnIds) ([], env, []) sortedDefs
-      (errs3, env3) = foldr (checkTypes newFnIds) ([], env2) sortedDefs'
-   in (errs1 ++ errs2 ++ errs3, env3)
+      (errs3, env3, sortedDefs'') = foldr (inferTypes newFnIds) ([], env2, []) sortedDefs'
+      (errs4, env4) = foldr (checkTypes newFnIds) ([], env3) sortedDefs''
+   in (errs1 ++ errs2 ++ errs3 ++ errs4, env4)
   where
     removeAlreadyDefined :: FnIds -> [FnDef] -> ([FnDefError], [FnDef])
     removeAlreadyDefined fids [] = ([], [])

--- a/src/Language/Dawn/Phase1/Display.hs
+++ b/src/Language/Dawn/Phase1/Display.hs
@@ -97,7 +97,7 @@ instance (Display a, Display b) => Display (a, b) where
   display (a, b) = "(" ++ display a ++ ", " ++ display b ++ ")"
 
 instance Display MultiStack where
-  display (MultiStack m) = intercalate "\n" (map iter (Map.toAscList m))
+  display (MultiStack m) = "{" ++ unwords (map iter (Map.toAscList m)) ++ "}"
     where
       iter (sid, vs) = sid ++ ": " ++ unwords (map display (reverse vs))
 

--- a/src/Language/Dawn/Phase1/Eval.hs
+++ b/src/Language/Dawn/Phase1/Eval.hs
@@ -178,6 +178,8 @@ evalWithFuel env ctx@(s : _) (fuel, EIntrinsic IApply, MultiStack m) =
       m' = insertListOrDelete s vs m
   in evalWithFuel env ctx (fuel - 1, e, MultiStack m')
 evalWithFuel env ctx (fuel, ECompose [], ms) = (fuel, ECompose [], ms)
+evalWithFuel env ctx (fuel, ECompose [ECompose es], ms) =
+  evalWithFuel env ctx (fuel, ECompose es, ms)
 evalWithFuel env ctx (fuel, ECompose (e : es), ms) =
   case evalWithFuel env ctx (fuel, e, ms) of
     (fuel', ECompose [], ms') -> evalWithFuel env ctx (fuel', ECompose es, ms')

--- a/test/Language/Dawn/Phase1/ParseSpec.hs
+++ b/test/Language/Dawn/Phase1/ParseSpec.hs
@@ -251,3 +251,23 @@ spec = do
       let (Right e) = parseExpr fibExprSrc
       parseFnDef fibSrc
         `shouldBe` Right (FnDef "fib" e)
+
+    it "parses tail recursive fib" $ do
+      let fibExprSrc = "0 1 _fib"
+      let fibSrc = "{fn fib => " ++ fibExprSrc ++ "}"
+      let (Right e) = parseExpr fibExprSrc
+      parseFnDef fibSrc
+        `shouldBe` Right (FnDef "fib" e)
+
+      let _fibExprSrc =
+            unlines
+              [ "  {spread $a $b}",
+                "  {match",
+                "    {case 0 => {$b drop} $a->}",
+                "    {case => decr $b-> clone $a-> add _fib}",
+                "  }"
+              ]
+      let _fibSrc = "{fn _fib => " ++ _fibExprSrc ++ "}"
+      let (Right e) = parseExpr _fibExprSrc
+      parseFnDef _fibSrc
+        `shouldBe` Right (FnDef "_fib" e)


### PR DESCRIPTION
Add the `:trace` command to `dawni`. This command traces the evaluation of an expression. For example:

```
> :trace 2 2 add {match {case 4 => True} {case => drop False}}
{} 2 2 add {match {case 4 => True} {case  => drop False}}
{$: 2} 2 add {match {case 4 => True} {case  => drop False}}
{$: 2 2} add {match {case 4 => True} {case  => drop False}}
{$: 4} {match {case 4 => True} {case  => drop False}}
{} True
{$: True}
```