### PR TITLE
Cleanup defineFns

### DIFF
--- a/src/Language/Dawn/Phase1/Core.hs
+++ b/src/Language/Dawn/Phase1/Core.hs
@@ -20,7 +20,6 @@ module Language.Dawn.Phase1.Core
     Context,
     DataDef (..),
     DataDefError (..),
-    defineFn,
     emptyEnv,
     ensureUniqueStackId,
     Env (..),
@@ -968,11 +967,6 @@ addFnDefs env@Env {fnDefs} defs =
       case checkType env ["$"] e (fnTypes Map.! fid) of
         Left err -> (FnTypeError fid err : errs, env {fnTypes = Map.delete fid fnTypes})
         Right () -> (errs, env)
-
-defineFn :: Env -> FnDef -> Either FnDefError Env
-defineFn env def = case addFnDefs env [def] of
-  ([], env') -> return env'
-  ([err], _) -> throwError err
 
 ------------------------------------
 -- Algebraic Data Type Definition --

--- a/src/Language/Dawn/Phase1/Core.hs
+++ b/src/Language/Dawn/Phase1/Core.hs
@@ -11,6 +11,7 @@ module Language.Dawn.Phase1.Core
     ($:),
     ($.),
     addDataDefs,
+    addFnDefs,
     addMissingStacks,
     checkType,
     composeSubst,
@@ -20,7 +21,6 @@ module Language.Dawn.Phase1.Core
     DataDef (..),
     DataDefError (..),
     defineFn,
-    defineFns,
     emptyEnv,
     ensureUniqueStackId,
     Env (..),
@@ -931,8 +931,8 @@ fnDepsSort defs =
   where
     fnDefToEdgeList exprToDeps def@(FnDef fid e) = (def, fid, Set.toList (exprToDeps e))
 
-defineFns :: Env -> [FnDef] -> ([FnDefError], Env)
-defineFns env@Env {fnDefs} defs =
+addFnDefs :: Env -> [FnDef] -> ([FnDefError], Env)
+addFnDefs env@Env {fnDefs} defs =
   let existingFnIds = Map.keysSet fnDefs `Set.union` intrinsicFnIds
       (errs1, defs') = removeAlreadyDefined existingFnIds defs
       newFnIds = Set.fromList (map fnDefFnId defs')
@@ -970,7 +970,7 @@ defineFns env@Env {fnDefs} defs =
         Right () -> (errs, env)
 
 defineFn :: Env -> FnDef -> Either FnDefError Env
-defineFn env def = case defineFns env [def] of
+defineFn env def = case addFnDefs env [def] of
   ([], env') -> return env'
   ([err], _) -> throwError err
 

--- a/src/Language/Dawn/Phase1/Display.hs
+++ b/src/Language/Dawn/Phase1/Display.hs
@@ -96,6 +96,13 @@ instance Display TypeError where
   display (UndefinedCons cid) = "undefined constructor: " ++ cid
   display (UndefinedFn fid) = "undefined function: " ++ fid
 
+instance Display FnDefError where
+  display err@(FnAlreadyDefined fid) = show err
+  display (FnTypeError fid err) = "type error: " ++ display err
+  display (FnStackError fid sids) =
+    let s = intercalate ", " (Set.toList sids)
+     in "exposed temporary stacks: " ++ s
+
 instance Display DataDefError where
   display (TypeConsArityMismatch tcid t) =
     unwords ["TypeConsArityMismatch", tcid, display t]

--- a/test/Language/Dawn/Phase1/CoreSpec.hs
+++ b/test/Language/Dawn/Phase1/CoreSpec.hs
@@ -502,7 +502,7 @@ spec = do
       let fnDefs = [f, h, g]
       mapM_ (\defs -> fnDepsSort defs `shouldBe` fnDefs) (permutations fnDefs)
 
-  describe "defineFns examples" $ do
+  describe "addFnDefs examples" $ do
     it "defines drop2 and drop3" $ do
       let (Right drop2) = parseFnDef "{fn drop2 => drop drop}"
       let (Right drop3) = parseFnDef "{fn drop3 => drop2 drop}"
@@ -517,7 +517,7 @@ spec = do
                       ]
                 }
             )
-      defineFns emptyEnv [drop2, drop3]
+      addFnDefs emptyEnv [drop2, drop3]
         `shouldBe` (errs, env)
 
     it "defines mutually recursive fns" $ do
@@ -573,7 +573,7 @@ spec = do
                       ]
                 }
             )
-      defineFns emptyEnv [is_odd, decr_even, decr_odd, count_down]
+      addFnDefs emptyEnv [is_odd, decr_even, decr_odd, count_down]
         `shouldBe` (errs, env)
 
     it "succeeds on direct recursion in one match case" $ do
@@ -596,13 +596,13 @@ spec = do
               { fnDefs = Map.singleton "fib" fib,
                 fnTypes = Map.singleton "fib" fib_t
               }
-      defineFns emptyEnv [fib] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [fib] `shouldBe` (errs, env)
 
     it "fails on direct recursion outside of match expr" $ do
       let (Right diverge) = parseFnDef "{fn diverge => drop diverge 1}"
       let errs = [FnTypeError "diverge" (UndefinedFn "diverge")]
       let env = emptyEnv
-      defineFns emptyEnv [diverge] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [diverge] `shouldBe` (errs, env)
 
     it "fails on direct recursion in all match cases" $ do
       let (Right foo) =
@@ -619,7 +619,7 @@ spec = do
       let foo_t = forall' [v0] (v0 * tU32 --> v0 * tU32)
       let errs = [FnTypeError "foo" (UndefinedFn "foo")]
       let env = emptyEnv
-      defineFns emptyEnv [foo] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [foo] `shouldBe` (errs, env)
 
     it "succeeds on mutual recursion in one match case in each function" $ do
       let (Right is_even) =
@@ -654,7 +654,7 @@ spec = do
               { fnDefs = Map.fromList [("is_even", is_even), ("is_odd", is_odd)],
                 fnTypes = Map.fromList [("is_even", is_even_t), ("is_odd", is_odd_t)]
               }
-      defineFns emptyEnv [is_even, is_odd] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [is_even, is_odd] `shouldBe` (errs, env)
 
     it "fails on mutual recursion outside of match expr" $ do
       let (Right f1) = parseFnDef "{fn f1 => decr f2}"
@@ -668,7 +668,7 @@ spec = do
               FnTypeError "f2" (UndefinedFn "f1")
             ]
       let env = emptyEnv
-      defineFns emptyEnv [f1, f2] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [f1, f2] `shouldBe` (errs, env)
 
     it "fails on mutual recursion in all match cases" $ do
       let (Right is_even) =
@@ -702,7 +702,7 @@ spec = do
               FnTypeError "is_odd" (UndefinedFn "is_even")
             ]
       let env = emptyEnv
-      defineFns emptyEnv [is_even, is_odd] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [is_even, is_odd] `shouldBe` (errs, env)
 
     it "succeeds on mutual recursion in all but some match cases in one function (1)" $ do
       let (Right is_even) =
@@ -728,7 +728,7 @@ spec = do
               { fnDefs = Map.fromList [("is_even", is_even), ("is_odd", is_odd)],
                 fnTypes = Map.fromList [("is_even", is_even_t), ("is_odd", is_odd_t)]
               }
-      defineFns emptyEnv [is_odd, is_even] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [is_odd, is_even] `shouldBe` (errs, env)
 
     it "succeeds on mutual recursion in all but some match cases in one function (2)" $ do
       let (Right is_odd) =
@@ -754,7 +754,7 @@ spec = do
               { fnDefs = Map.fromList [("is_even", is_even), ("is_odd", is_odd)],
                 fnTypes = Map.fromList [("is_even", is_even_t), ("is_odd", is_odd_t)]
               }
-      defineFns emptyEnv [is_odd, is_even] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [is_odd, is_even] `shouldBe` (errs, env)
 
     it "defines tail recursive fib" $ do
       let errs = []
@@ -778,7 +778,7 @@ spec = do
                       )
                     ]
               }
-      defineFns emptyEnv [fastFib, _fastFib] `shouldBe` (errs, env)
+      addFnDefs emptyEnv [fastFib, _fastFib] `shouldBe` (errs, env)
 
   describe "addDataDefs" $ do
     it "adds `{data Bit {cons B0} {cons B1}}`" $ do

--- a/test/Language/Dawn/Phase1/EvalSpec.hs
+++ b/test/Language/Dawn/Phase1/EvalSpec.hs
@@ -347,7 +347,7 @@ spec = do
       evalWithFuel emptyEvalEnv ["$"] (7, e, ms) `shouldBe` (0, e', ms')
 
     it "evals `fib`" $ do
-      let ([], env) = defineFns emptyEnv [swap, fib]
+      let ([], env) = addFnDefs emptyEnv [swap, fib]
           evalFib n =
             let (Right e) = parseExpr (show n ++ " fib")
                 ms = MultiStack Map.empty
@@ -369,7 +369,7 @@ spec = do
       evalFib 9 `shouldBe` 34 `inSteps` 1010
 
     it "evals tail recursive fib" $ do
-      let ([], env) = defineFns emptyEnv [fastFib, _fastFib]
+      let ([], env) = addFnDefs emptyEnv [fastFib, _fastFib]
           evalFastFib n =
             let (Right e) = parseExpr (show n ++ " fib")
                 ms = MultiStack Map.empty

--- a/test/Language/Dawn/Phase1/EvalSpec.hs
+++ b/test/Language/Dawn/Phase1/EvalSpec.hs
@@ -212,7 +212,7 @@ spec = do
       eval' e `shouldBe` ms
 
     it "evals `0 1 swap`" $ do
-      let (Right env) = defineFn emptyEnv swap
+      let ([], env) = addFnDefs emptyEnv [swap]
       let (Right e) = parseExpr "0 1 swap"
       let (Right vs) = parseValStack "1 0"
       let ms = MultiStack Map.empty
@@ -220,7 +220,7 @@ spec = do
       eval (toEvalEnv env) ["$"] e ms `shouldBe` ms'
 
     it "evals `{$c 0 1 swap}`" $ do
-      let (Right env) = defineFn emptyEnv swap
+      let ([], env) = addFnDefs emptyEnv [swap]
       let (Right e) = parseExpr "{$c 0 1 swap}"
       let (Right vs) = parseValStack "1 0"
       let ms = MultiStack Map.empty
@@ -228,7 +228,7 @@ spec = do
       eval (toEvalEnv env) ["$"] e ms `shouldBe` ms'
 
     it "evals `{$a 0 1 swap}`" $ do
-      let (Right env) = defineFn emptyEnv swap
+      let ([], env) = addFnDefs emptyEnv [swap]
       let (Right e) = parseExpr "{$a 0 1 swap}"
       let (Right vs) = parseValStack "1 0"
       let ms = MultiStack Map.empty
@@ -236,22 +236,21 @@ spec = do
       eval (toEvalEnv env) ["$"] e ms `shouldBe` ms'
 
     it "evals fib" $ do
-      let (Right env) = defineFn emptyEnv swap
-      let (Right env') = defineFn env fib
+      let ([], env) = addFnDefs emptyEnv [swap, fib]
       let (Right e) = parseExpr "0 fib"
       let (Right vs) = parseValStack "0"
       let ms = MultiStack (Map.singleton "$" vs)
-      eval (toEvalEnv env') ["$"] e (MultiStack Map.empty) `shouldBe` ms
+      eval (toEvalEnv env) ["$"] e (MultiStack Map.empty) `shouldBe` ms
 
       let (Right e) = parseExpr "1 fib"
       let (Right vs) = parseValStack "1"
       let ms = MultiStack (Map.singleton "$" vs)
-      eval (toEvalEnv env') ["$"] e (MultiStack Map.empty) `shouldBe` ms
+      eval (toEvalEnv env) ["$"] e (MultiStack Map.empty) `shouldBe` ms
 
       let (Right e) = parseExpr "6 fib"
       let (Right vs) = parseValStack "8"
       let ms = MultiStack (Map.singleton "$" vs)
-      eval (toEvalEnv env') ["$"] e (MultiStack Map.empty) `shouldBe` ms
+      eval (toEvalEnv env) ["$"] e (MultiStack Map.empty) `shouldBe` ms
 
     it "evals `B0 {match {case B0 => B1} {case B1 => B0}}`" $ do
       let (Right d) = parseDataDef "{data Bit {cons B0} {cons B1}}"


### PR DESCRIPTION
- rename `defineFns` to `addFnDefs`
- remove `defineFn`
- update `Dawni` to use `addFnDefs` and to support mutually recursive function definitions